### PR TITLE
made wheels turn off when robot is stopped

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumWheels.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumWheels.java
@@ -84,5 +84,15 @@ public class MecanumWheels extends LinearOpMode {
 
             telemetry.update();
         }
+
+        // Turn off all wheels when done
+        robot.frontLeft.setPower(0);
+        robot.frontRight.setPower(0);
+        robot.backLeft.setPower(0);
+        robot.backRight.setPower(0);
+
+        // Display that robot stopped, and total run time
+        telemetry.addData("Finished", "Run Time: " + runtime.toString());
+        telemetry.update();
     }
 }


### PR DESCRIPTION
The FTC Robot guide recommends turning off all motors after the main loop. This is added just to be 100% sure that no matter what, the wheels will stop when the robot is stopped. 